### PR TITLE
syntactical sugar

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,6 @@ Assert.areEqual('2533', response.zip4, 'Well, hello Zip+4.');
 
 You get the picture: use `USPSCityStateLookupRequest`.
 
-# ⚠️ Bulkification Warning
+## ⚠️ Bulkification Warning
 
 Be aware that the USPS Address API can only validate 5 addresses at a time, so the callouts are batched accordingly. If you build 10 request objects, you will consume 2 callouts. If you build 501 request objects, [your transaction will fail](https://developer.salesforce.com/docs/atlas.en-us.apexcode.meta/apexcode/apex_callouts_timeouts.htm). This warning applies to both ***Flow Support*** and ***Apex Support***.

--- a/force-app/main/default/classes/USPSRequestAuraEnabled.cls
+++ b/force-app/main/default/classes/USPSRequestAuraEnabled.cls
@@ -12,14 +12,14 @@ public with sharing class USPSRequestAuraEnabled {
 
     public USPSAddressValidateRequest buildAddressValidateRequest(){
         USPSAddressValidateRequest validate = new USPSAddressValidateRequest()
-        .setFirmName(firmName)
-        .setAddress1(address1)
-        .setAddress2(address2)
-        .setCity(city)
-        .setState(state)
-        .setUrbanization(urbanization)
-        .setZip5(zip5)
-        .setZip4(zip4);
+        .setFirmName(this.firmName)
+        .setAddress1(this.address1)
+        .setAddress2(this.address2)
+        .setCity(this.city)
+        .setState(this.state)
+        .setUrbanization(this.urbanization)
+        .setZip5(this.zip5)
+        .setZip4(this.zip4);
         return validate;
     }
 

--- a/force-app/main/default/permissionsets/USPS_Address_API_User.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/USPS_Address_API_User.permissionset-meta.xml
@@ -1,5 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <PermissionSet xmlns="http://soap.sforce.com/2006/04/metadata">
+    <classAccesses>
+        <apexClass>USPSAddressAPIInvocable</apexClass>
+        <enabled>true</enabled>
+    </classAccesses>
+    <classAccesses>
+        <apexClass>USPSRequestAuraEnabled</apexClass>
+        <enabled>true</enabled>
+    </classAccesses>
+    <classAccesses>
+        <apexClass>USPSResponseAuraEnabled</apexClass>
+        <enabled>true</enabled>
+    </classAccesses>
     <customMetadataTypeAccesses>
         <enabled>true</enabled>
         <name>USPS_Address_API_Setting__mdt</name>

--- a/unpackaged/config/demo-app/permissionsets/USPS_Address_API_Demo_Viewer.permissionset-meta.xml
+++ b/unpackaged/config/demo-app/permissionsets/USPS_Address_API_Demo_Viewer.permissionset-meta.xml
@@ -1,19 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <PermissionSet xmlns="http://soap.sforce.com/2006/04/metadata">
     <classAccesses>
-        <apexClass>USPSResponseAuraEnabled</apexClass>
-        <enabled>true</enabled>
-    </classAccesses>
-    <classAccesses>
         <apexClass>USPSAddressAPIDemoController</apexClass>
-        <enabled>true</enabled>
-    </classAccesses>
-    <classAccesses>
-        <apexClass>USPSAddressAPIInvocable</apexClass>
-        <enabled>true</enabled>
-    </classAccesses>
-    <classAccesses>
-        <apexClass>USPSRequestAuraEnabled</apexClass>
         <enabled>true</enabled>
     </classAccesses>
     <hasActivationRequired>false</hasActivationRequired>


### PR DESCRIPTION
# Changes
1. Adjust header size of Bulkification Warning in README
2. Added syntactical sugar in `USPSRequestAuraEnabled.buildAddressValidateRequest()`
3. Moved Apex permissions in between permission sets:
     - The package's base permission set `USPS_Address_API_User` now has access to the Invocable class, and both of the Aura Enabled classes
     - Because the base permission set now has this access, access to those Apex classes has been removed from the demo app permission set
